### PR TITLE
Container.registerService() should support tokenized services from factories

### DIFF
--- a/test/Container.spec.ts
+++ b/test/Container.spec.ts
@@ -264,6 +264,35 @@ describe("Container", function() {
 
         });
 
+        it("should support tokenized services from factories", function() {
+
+            interface Vehicle {
+                getColor(): string;
+            }
+
+            class Bus implements Vehicle {
+                getColor (): string {
+                    return "yellow";
+                }
+            }
+
+            class VehicleFactory {
+                createBus(): Vehicle {
+                    return new Bus();
+                }
+            }
+
+            const VehicleService = new Token<Vehicle>();
+
+            Container.registerService({
+                id: VehicleService,
+                factory: [VehicleFactory, "createBus"]
+            });
+
+            Container.get(VehicleService).getColor().should.be.equal("yellow");
+
+        });
+
     });
 
 });


### PR DESCRIPTION
Hello!

I've added a failing test to demonstrate the issue with some use case, i.e. when you want to manually register a factory service using service token. For some reason such service couldn't be retrieved from the container later on.